### PR TITLE
Allow for proposed new parsing of array[end]

### DIFF
--- a/src/PEG.jl
+++ b/src/PEG.jl
@@ -192,7 +192,7 @@ function to_rule(::Val{:ref}, fn, range::Expr)
   local m
   local n
   m, n = range.args[2:3]
-  n == :end && (n = Inf)
+  (n == :end || n == Expr(:end)) && (n = Inf)
   local sym = gensym("[$m:$n]")
   :((input, cache)->cache_rule($(Meta.quot(sym)), (input, cache)->begin
     local results = []


### PR DESCRIPTION
To fix https://github.com/JuliaLang/julia/issues/57269, a small-but-breaking julia AST change is needed (PR + discussion https://github.com/JuliaLang/julia/pull/57368).

PEG.jl is currently incompatible with the new parsing, which causes a handful of packages to fail while evaluating the parsing change.  This PR makes PEG.jl work with the new parsing, and shouldn't change its compatibility with any existing version of julia.

Note that the parsing change isn't merged yet, but it's planned to be.  If the change is cancelled, I'll come back and remove the code I've added here.